### PR TITLE
fix: available time notification

### DIFF
--- a/__tests__/domain/models/available_time/available_time.spec.ts
+++ b/__tests__/domain/models/available_time/available_time.spec.ts
@@ -60,16 +60,19 @@ describe('AvailableTime', () => {
       it('calculates available time by ms', () => {
         const weeklyEvents = [
           {
+            title: 'meeting',
             willAttend: true,
             eventStartAt: new Date(2020, 8, 25, 18, 0, 0, 0),
             eventEndAt: new Date(2020, 8, 25, 19, 0, 0, 0),
           },
           {
+            title: 'meeting',
             willAttend: true,
             eventStartAt: new Date(2020, 8, 25, 11, 30, 0, 0),
             eventEndAt: new Date(2020, 8, 25, 12, 30, 0, 0),
           },
           {
+            title: 'meeting',
             willAttend: false,
             eventStartAt: new Date(2020, 8, 25, 15, 0, 0, 0),
             eventEndAt: new Date(2020, 8, 25, 16, 0, 0, 0),
@@ -77,7 +80,51 @@ describe('AvailableTime', () => {
         ];
 
         const availableWorkHours = AvailableTime.WORK_HOURS_PER_WEEK;
-        const maxTime = availableWorkHours * 60 * 60 * 1000;
+        const maxTime = (availableWorkHours + 1) * 60 * 60 * 1000;
+
+        const result = AvailableTime.calculateAvailableTime(
+          weeklyEvents,
+          workStartHour,
+          workStartMinute,
+          workEndHour,
+          workEndMinute,
+          availableWorkHours,
+        );
+        expect(result).toBe(maxTime - 2 * 60 * 60 * 1000);
+      });
+    });
+
+    describe('when exists break time', () => {
+      it('calculates available time by ms', () => {
+        const weeklyEvents = [
+          {
+            title: 'meeting',
+            willAttend: true,
+            eventStartAt: new Date(2020, 8, 25, 18, 0, 0, 0),
+            eventEndAt: new Date(2020, 8, 25, 19, 0, 0, 0),
+          },
+          {
+            title: 'meeting',
+            willAttend: true,
+            eventStartAt: new Date(2020, 8, 25, 11, 30, 0, 0),
+            eventEndAt: new Date(2020, 8, 25, 12, 30, 0, 0),
+          },
+          {
+            title: 'break',
+            willAttend: true,
+            eventStartAt: new Date(2020, 8, 25, 13, 30, 0, 0),
+            eventEndAt: new Date(2020, 8, 25, 14, 30, 0, 0),
+          },
+          {
+            title: 'meeting',
+            willAttend: false,
+            eventStartAt: new Date(2020, 8, 25, 15, 0, 0, 0),
+            eventEndAt: new Date(2020, 8, 25, 16, 0, 0, 0),
+          },
+        ];
+
+        const availableWorkHours = AvailableTime.WORK_HOURS_PER_WEEK;
+        const maxTime = (availableWorkHours + 1) * 60 * 60 * 1000;
 
         const result = AvailableTime.calculateAvailableTime(
           weeklyEvents,
@@ -95,21 +142,25 @@ describe('AvailableTime', () => {
       it('calculates available time by ms', () => {
         const weeklyEvents = [
           {
+            title: 'meeting',
             willAttend: true,
             eventStartAt: new Date(2020, 8, 25, 18, 30, 0, 0),
             eventEndAt: new Date(2020, 8, 25, 19, 0, 0, 0),
           },
           {
+            title: 'meeting',
             willAttend: true,
             eventStartAt: new Date(2020, 8, 25, 18, 0, 0, 0),
             eventEndAt: new Date(2020, 8, 25, 19, 0, 0, 0),
           },
           {
+            title: 'meeting',
             willAttend: true,
             eventStartAt: new Date(2020, 8, 25, 11, 30, 0, 0),
             eventEndAt: new Date(2020, 8, 25, 12, 30, 0, 0),
           },
           {
+            title: 'meeting',
             willAttend: false,
             eventStartAt: new Date(2020, 8, 25, 15, 0, 0, 0),
             eventEndAt: new Date(2020, 8, 25, 16, 0, 0, 0),
@@ -117,7 +168,7 @@ describe('AvailableTime', () => {
         ];
 
         const availableWorkHours = AvailableTime.WORK_HOURS_PER_WEEK;
-        const maxTime = availableWorkHours * 60 * 60 * 1000;
+        const maxTime = (availableWorkHours + 1) * 60 * 60 * 1000;
 
         const result = AvailableTime.calculateAvailableTime(
           weeklyEvents,
@@ -135,21 +186,25 @@ describe('AvailableTime', () => {
       it('calculates available time by ms', () => {
         const weeklyEvents = [
           {
+            title: 'meeting',
             willAttend: true,
             eventStartAt: new Date(2020, 8, 25, 18, 0, 0, 0),
             eventEndAt: new Date(2020, 8, 25, 19, 0, 0, 0),
           },
           {
+            title: 'meeting',
             willAttend: true,
             eventStartAt: new Date(2020, 8, 25, 11, 30, 0, 0),
             eventEndAt: new Date(2020, 8, 25, 12, 30, 0, 0),
           },
           {
+            title: 'meeting',
             willAttend: false,
             eventStartAt: new Date(2020, 8, 25, 15, 0, 0, 0),
             eventEndAt: new Date(2020, 8, 25, 16, 0, 0, 0),
           },
           {
+            title: 'meeting',
             willAttend: true,
             eventStartAt: new Date(2020, 8, 25, 18, 0, 0, 0),
             eventEndAt: new Date(2020, 8, 25, 21, 0, 0, 0),
@@ -157,7 +212,7 @@ describe('AvailableTime', () => {
         ];
 
         const availableWorkHours = AvailableTime.WORK_HOURS_PER_WEEK;
-        const maxTime = availableWorkHours * 60 * 60 * 1000;
+        const maxTime = (availableWorkHours + 1) * 60 * 60 * 1000;
 
         const result = AvailableTime.calculateAvailableTime(
           weeklyEvents,
@@ -175,21 +230,25 @@ describe('AvailableTime', () => {
       it('calculates available time by ms', () => {
         const weeklyEvents = [
           {
+            title: 'meeting',
             willAttend: true,
             eventStartAt: new Date(2020, 8, 25, 18, 0, 0, 0),
             eventEndAt: new Date(2020, 8, 25, 19, 0, 0, 0),
           },
           {
+            title: 'meeting',
             willAttend: true,
             eventStartAt: new Date(2020, 8, 25, 11, 30, 0, 0),
             eventEndAt: new Date(2020, 8, 25, 12, 30, 0, 0),
           },
           {
+            title: 'meeting',
             willAttend: false,
             eventStartAt: new Date(2020, 8, 25, 15, 0, 0, 0),
             eventEndAt: new Date(2020, 8, 25, 16, 0, 0, 0),
           },
           {
+            title: 'meeting',
             willAttend: true,
             eventStartAt: new Date(2020, 8, 25, 8, 0, 0, 0),
             eventEndAt: new Date(2020, 8, 25, 10, 0, 0, 0),
@@ -197,7 +256,7 @@ describe('AvailableTime', () => {
         ];
 
         const availableWorkHours = AvailableTime.WORK_HOURS_PER_WEEK;
-        const maxTime = availableWorkHours * 60 * 60 * 1000;
+        const maxTime = (availableWorkHours + 1) * 60 * 60 * 1000;
 
         const result = AvailableTime.calculateAvailableTime(
           weeklyEvents,
@@ -215,21 +274,25 @@ describe('AvailableTime', () => {
       it('calculates available time by ms', () => {
         const weeklyEvents = [
           {
+            title: 'meeting',
             willAttend: true,
             eventStartAt: new Date(2020, 8, 25, 18, 0, 0, 0),
             eventEndAt: new Date(2020, 8, 25, 19, 0, 0, 0),
           },
           {
+            title: 'meeting',
             willAttend: true,
             eventStartAt: new Date(2020, 8, 25, 11, 30, 0, 0),
             eventEndAt: new Date(2020, 8, 25, 12, 30, 0, 0),
           },
           {
+            title: 'meeting',
             willAttend: false,
             eventStartAt: new Date(2020, 8, 25, 15, 0, 0, 0),
             eventEndAt: new Date(2020, 8, 25, 16, 0, 0, 0),
           },
           {
+            title: 'meeting',
             willAttend: true,
             eventStartAt: new Date(2020, 8, 25, 8, 0, 0, 0),
             eventEndAt: new Date(2020, 8, 25, 10, 0, 0, 0),
@@ -237,7 +300,7 @@ describe('AvailableTime', () => {
         ];
 
         const availableWorkHours = AvailableTime.WORK_HOURS_PER_DAY;
-        const maxTime = availableWorkHours * 60 * 60 * 1000;
+        const maxTime = (availableWorkHours + 1) * 60 * 60 * 1000;
 
         const result = AvailableTime.calculateAvailableTime(
           weeklyEvents,

--- a/src/use_case/available_time/available_time_input_data_base.ts
+++ b/src/use_case/available_time/available_time_input_data_base.ts
@@ -6,10 +6,11 @@ export abstract class AvailableTimeInputDataBase {
 
   mapEvents(calendarEvents: CalendarEvent[]): Event[] {
     return calendarEvents.map((e) => {
+      const title = e.getTitle();
       const willAttend = this.willAttend(e.getMyStatus());
       const eventStartAt: Date = Moment.moment(e.getStartTime()).toDate();
       const eventEndAt: Date = Moment.moment(e.getEndTime()).toDate();
-      return { willAttend, eventStartAt, eventEndAt };
+      return { title, willAttend, eventStartAt, eventEndAt };
     });
   }
 


### PR DESCRIPTION
# Issue
- 10~19時の終日スケジュールが入っていると実装可能時間がマイナスになるbugがあったので修正
- 結論としては、休憩時間が考慮されていなかったため、10~19時で予定が入っていると業務時間の8時間を超えて1時間分マイナスの状態で計算されていたのが原因