### PR TITLE
fix: logic in isAlreadyStarted method

### DIFF
--- a/src/domain/models/measurement/measurement.ts
+++ b/src/domain/models/measurement/measurement.ts
@@ -139,6 +139,9 @@ export class Measurement {
   }
 
   static isAlreadyStarted(lastMeasurement: Measurement): boolean {
-    return typeof lastMeasurement.getMeasurementStopAt() === 'undefined';
+    // NOTE: 元々、typeof lastMeasurement.getMeasurementStopAt() === 'undefined'としていたが、
+    // cacheを使用するとundefinedが空文字として入るためロジックを修正
+    // FIXME: 暗黙的になっているので設計を見直すべき
+    return !lastMeasurement.getMeasurementStopAt();
   }
 }


### PR DESCRIPTION
# Issue
- cacheを使うことで/measurement stopコマンドが使えなくなるbugが発生